### PR TITLE
Add Register method to struct.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -83,27 +83,21 @@ func (x *opBot) Run() {
 			// User commands.
 			case update.Message.IsCommand():
 				cmd := strings.ToLower(update.Message.Command())
-				found := false
 
-				for c, bcmd := range x.commands {
-					if c == cmd {
-						found = true
-
-						// Fail silently if non-private request on private only command.
-						if bcmd.pvtOnly && !isPrivateChat(update.Message.Chat) {
-							log.Printf("Ignoring non-private request on private only command %q", cmd)
-							break
-						}
-						// Handle command.
-						err := bcmd.handler(update)
-						if err != nil {
-							x.sendReply(update, err.Error())
-						}
-						break
-					}
+				bcmd, ok := x.commands[cmd]
+				if !ok {
+					log.Printf("Ignoring invalid command: %q", cmd)
+					break
 				}
-				if !found {
-					log.Printf("Ignoring invalid command %q", cmd)
+				// Fail silently if non-private request on private only command.
+				if bcmd.pvtOnly && !isPrivateChat(update.Message.Chat) {
+					log.Printf("Ignoring non-private request on private only command %q", cmd)
+					break
+				}
+				// Handle command.
+				err := bcmd.handler(update)
+				if err != nil {
+					x.sendReply(update, err.Error())
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -35,16 +35,12 @@ func main() {
 		messages: messages,
 		bot:      bot,
 	}
-
-	// TODO: Create "Set" functions inside opbot so we can set botCommands
-	// externally without mucking with the internals of the struct.
-	b.commands = []botCommand{
-		botCommand{"indent", "Indenta um programa no repl.it (/indent url)", false, b.indentHandler},
-		botCommand{"hackerdetected", "Dispara o alarme anti-hacker. :)", false, b.hackerHandler},
-		botCommand{"setlocation", "Atualiza posição geográfica usando código postal (/setlocation <pais> <código postal>)", true, b.locationHandler},
-		botCommand{"cep", "Atualiza posição geográfica usando CEP", true, b.locationHandler},
-		botCommand{"help", "Mensagem de help", true, b.helpHandler},
-	}
+	// Register commands
+	b.Register("indent", "Indenta um programa no repl.it (/indent url)", false, true, b.indentHandler)
+	b.Register("hackerdetected", "Dispara o alarme anti-hacker. :)", false, true, b.hackerHandler)
+	b.Register("setlocation", "Atualiza posição geográfica usando código postal (/setlocation <pais> <código postal>)", true, true, b.locationHandler)
+	b.Register("cep", "Atualiza posição geográfica usando CEP", true, true, b.locationHandler)
+	b.Register("help", "Mensagem de help", true, true, b.helpHandler)
 
 	// Make it so!
 	b.Run()


### PR DESCRIPTION
- Add a "Register" method to the opBot struct. We don't need to
  initialize commands directly when creating the structure.
- botCommand is now a map, for better code efficiency and readability.
- Added the "enabled" field on botCommands. This will allow us to
  enable and disable commands later (right now, it's a no-op).