### PR TITLE
Improve detection of forwarded messages

### DIFF
--- a/src/bot.go
+++ b/src/bot.go
@@ -104,7 +104,7 @@ func (x *opBot) Run(bot *tgbotapi.BotAPI) {
 
 			switch {
 			// Forward message handling.
-			case update.Message.ForwardFrom != nil && x.config.DeleteFwd:
+			case x.config.DeleteFwd && isForwarded(update.Message):
 				// Remove forwarded message and log.
 				bot.DeleteMessage(tgbotapi.DeleteMessageConfig{
 					ChatID:    update.Message.Chat.ID,

--- a/src/util.go
+++ b/src/util.go
@@ -105,6 +105,15 @@ func isPrivateChat(chat *tgbotapi.Chat) bool {
 	return chat.Type == "private"
 }
 
+// isForwarded returns true if the received message is forwarded; false
+// otherwise.
+func isForwarded(msg *tgbotapi.Message) bool {
+	if msg == nil {
+		return false
+	}
+	return msg.ForwardFrom != nil || msg.ForwardFromChat != nil
+}
+
 // trDelete returns a copy of the string with all runes in substring removed.
 func trDelete(s, substr string) string {
 	ret := bytes.Buffer{}

--- a/src/util_test.go
+++ b/src/util_test.go
@@ -1,0 +1,57 @@
+// Unit tests for the util module.
+package main
+
+import (
+	"gopkg.in/telegram-bot-api.v4"
+	"testing"
+)
+
+func TestIsForwarded(t *testing.T) {
+	caseTests := []struct {
+		message  *tgbotapi.Message // Message from the received update.
+		expected bool              // Result expected.
+	}{
+		{
+			// nil message.
+			message:  nil,
+			expected: false,
+		},
+		{
+			// Regular message.
+			message: &tgbotapi.Message{
+				Text: "something here",
+			},
+			expected: false,
+		},
+		{
+			// Forwarded message with ForwardFrom.
+			message: &tgbotapi.Message{
+				ForwardFrom: &tgbotapi.User{
+					ID:        42,
+					FirstName: "Foo",
+					LastName:  "Bar",
+				},
+				Text: "A simple forwarded message",
+			},
+			expected: true,
+		},
+		{
+			// Forwarded message with ForwardFromChat.
+			message: &tgbotapi.Message{
+				ForwardFromChat: &tgbotapi.Chat{
+					ID:    42,
+					Type:  "channel",
+					Title: "Foo Bar",
+				},
+				Text: "Another forwarded message",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range caseTests {
+		if isForwarded(tt.message) != tt.expected {
+			t.Errorf("isForwarded handled %v incorrectly; expected: %v, got: %v", tt.message, tt.expected, !tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
In some cases -- probably when a user/channel does not exists any longer
--, the forwarded message will not contain the ForwardFrom field, but
will contain ForwardFromChat instead, so we now check for either of
these.

Also add a test case for the function that checks for forwarded
messages.