### PR TITLE
Fix go version to 1.11.1 until we fix travis setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.x
+  - 1.11.1
 
 os:
   - linux


### PR DESCRIPTION
- Go 1.12 changed the path github.com/golang/lint/golint to
  golang.org/x/lint/golint.