### PR TITLE
Revert "Save JSON state files under XDG home."

### DIFF
--- a/src/ban.go
+++ b/src/ban.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"gopkg.in/telegram-bot-api.v4"
 	"log"
-	"path"
 	"strings"
 	"sync"
 )
@@ -64,18 +63,14 @@ type bans struct {
 }
 
 // newBans creates a new bans object.
-func newBans() (*bans, error) {
-	ddir, err := dataDir()
-	if err != nil {
-		return nil, err
-	}
+func newBans() *bans {
 	return &bans{
 		Requests: banRequestList{
 			NotificationThreshold: adminNotificationDefaultThreshold,
 			Bans:                  map[string]banRequest{},
 		},
-		requestedBansDB: path.Join(ddir, requestedBansDB),
-	}, nil
+		requestedBansDB: requestedBansDB,
+	}
 }
 
 // nolint: gocyclo

--- a/src/bot.go
+++ b/src/bot.go
@@ -108,32 +108,12 @@ func newOpBot(config botConfig) (opBot, error) {
 		return opBot{}, fmt.Errorf("error initializing stats: %v", err)
 	}
 
-	media, err := newBotMedia()
-	if err != nil {
-		return opBot{}, err
-	}
-
-	notifications, err := newNotifications()
-	if err != nil {
-		return opBot{}, err
-	}
-
-	bans, err := newBans()
-	if err != nil {
-		return opBot{}, err
-	}
-
-	geolocations, err := newGeolocations(config.LocationKey)
-	if err != nil {
-		return opBot{}, err
-	}
-
 	return opBot{
 		config:        config,
-		notifications: notifications,
-		media:         media,
-		bans:          bans,
-		geolocations:  geolocations,
+		notifications: newNotifications(),
+		media:         newBotMedia(),
+		bans:          newBans(),
+		geolocations:  newGeolocations(config.LocationKey),
 		statsWriter:   sw,
 
 		// TODO(marcopaganini): Change this to a config parameter.

--- a/src/location.go
+++ b/src/location.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"path"
 	"sync"
 )
 
@@ -35,17 +34,12 @@ type geoLocations struct {
 }
 
 // newGeolocations returns a new instance of geoLocations
-func newGeolocations(locationKey string) (*geoLocations, error) {
-	ddir, err := dataDir()
-	if err != nil {
-		return nil, err
-	}
-
+func newGeolocations(locationKey string) *geoLocations {
 	return &geoLocations{
 		coords:      map[string]geoLocation{},
 		locationKey: locationKey,
-		locationDB:  path.Join(ddir, locationDB),
-	}, nil
+		locationDB:  locationDB,
+	}
 }
 
 // readLocations reads locations from the locationDB file.

--- a/src/notifications.go
+++ b/src/notifications.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"gopkg.in/telegram-bot-api.v4"
 	"log"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,14 +21,10 @@ type notifications struct {
 }
 
 // newNotifications creates a new notification type.
-func newNotifications() (*notifications, error) {
-	ddir, err := dataDir()
-	if err != nil {
-		return nil, err
-	}
+func newNotifications() *notifications {
 	return &notifications{
-		notificationsDB: path.Join(ddir, notificationsDB),
-	}, nil
+		notificationsDB: notificationsDB,
+	}
 }
 
 // notificationHandler enables/disables user notifications.


### PR DESCRIPTION
This reverts commit 7a138f6b4b7095718780478addeb95c8ce6be5c9.

The files were already being loaded from the proper location. The
commit above introduced the path twice, causing an error.