### PR TITLE
Allow configurable probation time for new users.

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"time"
 )
 
 const (
@@ -44,8 +45,9 @@ type botConfig struct {
 	// Bots in this whitelist won't be automatically kicked.
 	BotWhitelist []string `toml:"bot_whitelist"`
 
-	// Activate new user restrictions? (can't post pictures, audio, etc)
-	RestrictNewUsers bool `toml:"restrict_new_users"`
+	// Restriction time for new users (can't post pictures, audio, etc)
+	// Set to 0 to disable this feature.
+	NewUserProbationTime time.Duration `toml:"new_user_probation_time"`
 }
 
 // loadConfig loads the configuration items for the bot from 'configFile' under
@@ -53,9 +55,9 @@ type botConfig struct {
 func loadConfig() (botConfig, error) {
 	// Hardwire some defaults and let the config override them.
 	config := botConfig{
-		RestrictNewUsers: true,
-		KickBots:         true,
-		DeleteFwd:        true,
+		NewUserProbationTime: time.Duration(24 * time.Hour),
+		KickBots:             true,
+		DeleteFwd:            true,
 	}
 
 	cfgdir, err := configDir()

--- a/src/main.go
+++ b/src/main.go
@@ -62,7 +62,7 @@ func main() {
 	opbot.Register("help", T("register_help"), false, true, true, opbot.helpHandler)
 	opbot.Register("notifications", T("notifications_help"), false, true, true, opbot.notifications.notificationHandler)
 	opbot.Register("ban", T("ban_help"), false, false, true, opbot.bans.banRequestHandler)
-	opbot.Register("restrict_new_users", T("restrict_new_users_help"), true, false, true, opbot.toggleNewUserRestrictionsHandler)
+	opbot.Register("new_users_probation_time", T("new_users_probation_time_help"), true, false, true, opbot.setNewUserProbationTimeHandler)
 	opbot.Register("welcome_message_ttl", T("welcome_message_ttl_help"), true, false, true, opbot.setWelcomeMessageTTLHandler)
 
 	// Make it so!

--- a/translations/en-us-all.toml
+++ b/translations/en-us-all.toml
@@ -14,7 +14,7 @@ register_hackerdetected = "Fire the anti-hacker countermeasures. :)"
 register_help = "Command help"
 notifications_help = "Enables/disables notifications"
 ban_help = "Reports message to admins. Remember to send the command in response to a message"
-restrict_new_users_help = "Enables/disables new user restrictions (new users can only send text messages)"
+new_users_probation_time = "Users must be in the group for this long to gain full privileges (E.g, 24h, 0 = disable feature)"
 welcome_message_ttl_help = "Set the time-to-live for the welcome messages (E.g: /welcome_message_ttl 5m)"
 
 # Error messages

--- a/translations/pt-br-all.toml
+++ b/translations/pt-br-all.toml
@@ -14,7 +14,7 @@ register_hackerdetected = "Dispara o alarme anti-hacker. :)"
 register_help = "Help dos comandos"
 notifications_help = "Ativa/desativa notificações"
 ban_help = "Reporta mensagem para os admins. Use este comando em resposta a uma mensagem"
-restrict_new_users_help = "Liga/Desliga restrições para novos usuários."
+new_users_probation_time = "Configura o tempo minimo de permanência no grupo para eliminar restrições de novos usuários (Ex: 24h, 0 = desabilita restrições)"
 welcome_message_ttl_help = "Configura o tempo de vida das mensagens de boas-vindas (Ex: /welcome_message_ttl 5m)"
 
 # Error messages


### PR DESCRIPTION
- New command: `/new_users_probation_time` sets the minimum time users
  must be in the group for the bot to consider them as regular users.
  Until that tenure in the group is reached, the bot treats users as
  "new users" and blocks any messages containing rich media content.
  Usage example: `/new_users_probation_time 720h` sets the probation
  time to 30 days. The time format follows Go's `time.ParseDuration`
  specifications, meaning it will accept specifiers like 7h30m and so
  on. The minimum time is 1h.  A value of zero disables restrictions to
  new users.

- Deprecate the `/restrict_new_users` command. Just set the probation time
  to zero to turn off limitations.

- Target of opportunity: Automatically remove warning message to new
  users (i.e. when they attempt to send rich-text messages) after 30m.