### PR TITLE
Auto build multiple architectures on tag creation.

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -1,0 +1,31 @@
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: "Build & test"
+        run: |
+          make arch
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            arch/*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
-.PHONY: clean test docker
+.PHONY: arch clean docker docker-force install test
 
 bin := op-bot
+bindir := /usr/local/bin
+archdir := arch
 src := $(wildcard src/*.go)
+git_tag := $(shell git describe --always --tags)
 
 # Default target
 ${bin}: Makefile ${src}
-	cd src && go build -v -o "../${bin}"
+	cd src && go build -v -ldflags "-X main.BuildVersion=${git_tag}" -o "../${bin}"
+
+install: ${bin}
+	install -m 755 "${bin}" "${bindir}"
 
 docker:
 	docker build -t ${USER}/op-bot .
@@ -20,3 +26,16 @@ test:
 clean:
 	cd src && go clean
 	rm -f "${bin}"
+	rm -rf "${archdir}"
+
+# Creates cross-compiled tarred versions (for releases).
+arch: Makefile ${src}
+	for ga in "linux/amd64" "linux/386" "linux/arm" "linux/arm64" "linux/mips" "linux/mipsle"; do \
+	  export GOOS="$${ga%/*}"; \
+	  export GOARCH="$${ga#*/}"; \
+	  dst="./${archdir}/$${GOOS}-$${GOARCH}"; \
+	  mkdir -p "$${dst}"; \
+	  go build -v -ldflags "-X main.Build=${git_tag}" -o "$${dst}/${bin}"; \
+	  install -m 644 LICENSE README.md "$${dst}"; \
+	  tar -C "${archdir}" -zcvf "${archdir}/${bin}-$${GOOS}-$${GOARCH}.tar.gz" "$${dst##*/}"; \
+	done

--- a/src/main.go
+++ b/src/main.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"log"
 	"net/http"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
 var (
+	// BuildVersion holds the git HEAD commit # at build time
+	// (or nil if the binary was not built using make).
+	BuildVersion string
+
 	// T holds our global translation function. We return blank
 	// by default to make test initialization simpler.
 	T = func(string) string {
@@ -54,6 +59,9 @@ func main() {
 	if err := opbot.geolocations.readLocations(); err != nil {
 		log.Printf("Error reading locations: %v (assuming no locations recorded)", err)
 	}
+
+	// Print version
+	log.Printf("Starting op-bo, Git Build: %s\n", BuildVersion)
 
 	// Start the HTTP server listing the location info.
 	opbot.geolocations.serveLocations()


### PR DESCRIPTION
- Automatically build multiple architectures on tag creation (use semver).
- Print build version to log on startup.