### PR TITLE
fix: stats error handling, logging bug in util, and typos

### DIFF
--- a/src/bot.go
+++ b/src/bot.go
@@ -15,7 +15,7 @@ const (
 	// osProgramadoresURL contains the main group URL.
 	osProgramadoresURL = "https://osprogramadores.com"
 
-	// osProgramadoresURL contains the main group URL.
+	// osProgramadoresRulesURL contains the group rules URL.
 	osProgramadoresRulesURL = "https://osprogramadores.com/regras/"
 
 	// osProgramadoresGroup is the group username.

--- a/src/main.go
+++ b/src/main.go
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	// Print version
-	log.Printf("Starting op-bo, Git Build: %s\n", BuildVersion)
+	log.Printf("Starting op-bot, Git Build: %s\n", BuildVersion)
 
 	// Start the HTTP server listing the location info.
 	opbot.geolocations.serveLocations()

--- a/src/stats.go
+++ b/src/stats.go
@@ -32,8 +32,7 @@ func initStats() (io.WriteCloser, error) {
 // saveStats saves information on the received message to statsDB file as CSV.
 func saveStats(w io.Writer, u *tgbotapi.Update) (string, error) {
 	if w == nil {
-		//FIXME: maybe indicate in the error that the stats file writer is nil?
-		return "", nil
+		return "", errors.New(T("stats_error_nil_writer"))
 	}
 
 	if u.Message == nil {

--- a/src/util.go
+++ b/src/util.go
@@ -142,7 +142,7 @@ func deleteMessage(bot deleteMessager, chatid int64, msgid int) error {
 	if err != nil {
 		log.Printf("Unable to delete message (chat_id=%d, message_id=%d). Something is wrong.", chatid, msgid)
 	}
-	log.Printf("Removed message_id %d from chat_id %d", chatid, msgid)
+	log.Printf("Removed message_id %d from chat_id %d", msgid, chatid)
 	return err
 }
 

--- a/translations/en-us-all.toml
+++ b/translations/en-us-all.toml
@@ -43,6 +43,7 @@ notifications_disabled = "notifications disabled"
 stats_error_saving = "Error while saving message stats: %s (unsaved data: %q)"
 stats_error_empty_message = "empty message received"
 stats_error_unknown_user = "message sent by unknown user"
+stats_error_nil_writer = "uninitialized stats writer"
 
 # Ban request messages.
 

--- a/translations/pt-br-all.toml
+++ b/translations/pt-br-all.toml
@@ -43,6 +43,7 @@ notifications_disabled = "notificações desativadas"
 stats_error_saving = "Erro ao tentar salvar estatísticas de mensagens: %s (dado não salvo: %q)"
 stats_error_empty_message = "mensagem vazia recebida"
 stats_error_unknown_user = "mensagem enviada por usuário desconhecido"
+stats_error_nil_writer = "escritor de estatísticas não inicializado"
 
 # Ban request messages.
 


### PR DESCRIPTION
Improved Error Handling in src/stats.go

Implemented the existing FIXME in the saveStats function.
The function now returns an explicit error when the stats writer is nil, instead of failing silently.

Added the stats_error_nil_writer translation key to both en-us-all.toml and pt-br-all.toml
to ensure localization consistency.

Fixed Logging Bug in src/util.go
Corrected the parameter order in the deleteMessage function's log message.
Previously, message_id and chat_id were swapped in the output.

Typos and Documentation Fixes:
src/main.go: Fixed a typo in the bot's startup log message ("Starting op-bo" to "Starting op-bot").
src/bot.go: Adjusted an inconsistent comment where the group rules URL variable was being described with a generic label.