### PR TITLE
feat: Add 3-strike anti-spam system for captchas

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.24'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,9 +10,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.24'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
-          working-directory: src

--- a/src/ban.go
+++ b/src/ban.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	tgbotapi "github.com/osprogramadores/telegram-bot-api"
 )
@@ -322,5 +323,15 @@ func unBanUser(bot unbanChatMemberer, chatID int64, userID int) error {
 func kickUser(bot kickChatMemberer, chatID int64, userID int) error {
 	memberConfig := tgbotapi.ChatMemberConfig{ChatID: chatID, UserID: userID}
 	_, err := bot.KickChatMember(tgbotapi.KickChatMemberConfig{ChatMemberConfig: memberConfig})
+	return err
+}
+
+// kickUserUntil bans a user until a specific time.
+func kickUserUntil(bot kickChatMemberer, chatID int64, userID int, until time.Time) error {
+	memberConfig := tgbotapi.ChatMemberConfig{ChatID: chatID, UserID: userID}
+	_, err := bot.KickChatMember(tgbotapi.KickChatMemberConfig{
+		ChatMemberConfig: memberConfig,
+		UntilDate: until.Unix(),
+	})
 	return err
 }

--- a/src/ban.go
+++ b/src/ban.go
@@ -331,7 +331,7 @@ func kickUserUntil(bot kickChatMemberer, chatID int64, userID int, until time.Ti
 	memberConfig := tgbotapi.ChatMemberConfig{ChatID: chatID, UserID: userID}
 	_, err := bot.KickChatMember(tgbotapi.KickChatMemberConfig{
 		ChatMemberConfig: memberConfig,
-		UntilDate: until.Unix(),
+		UntilDate:        until.Unix(),
 	})
 	return err
 }

--- a/src/bot.go
+++ b/src/bot.go
@@ -33,6 +33,9 @@ type opBot struct {
 	// List of users not yet validated by captcha.
 	pendingCaptcha *pendingCaptchaType
 
+	// Track captcha failures across sessions
+	captchaFails *captchaFailures
+
 	// Don't send warning messages to new users on every infraction.
 	newUserWarningCache *cache.Cache
 
@@ -83,6 +86,7 @@ func newOpBot(config botConfig) (opBot, error) {
 
 		newUserCache:   cache.New(duration, duration),
 		pendingCaptcha: newPendingCaptchaType(),
+		captchaFails:   newCaptchaFailures(),
 
 		// How often will re-send warning messages to offending new users.
 		newUserWarningCache: cache.New(30*time.Minute, time.Hour),
@@ -221,7 +225,11 @@ func (x *opBot) Run(bot *tgbotapi.BotAPI) {
 						// and exit normally.
 						promCaptchaValidatedCount.Inc()
 						x.pendingCaptcha.del(userid)
+						x.captchaFails.reset(userid)
 						x.sendWelcome(bot, update, *update.Message.From)
+					} else {
+						promCaptchaFailedCount.Inc()
+						x.handleCaptchaFailure(bot, chatid, msgid, *update.Message.From)
 					}
 					continue
 				}

--- a/src/captcha.go
+++ b/src/captcha.go
@@ -244,18 +244,18 @@ func (x *opBot) handleCaptchaFailure(bot tgbotInterface, chatID int64, messageID
 
 	switch fails {
 	case 1:
-		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s não respondeu ao captcha e foi removido do grupo.", name))
+		sendMessage(bot, chatID, fmt.Sprintf(T("captcha_fail_1"), name))
 		kickUser(bot, chatID, user.ID)
 		unBanUser(bot, chatID, user.ID)
 	case 2:
-		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s não respondeu ao captcha e foi removido. Aviso: Se tentar de novo e errar será removido por 24h.", name))
+		sendMessage(bot, chatID, fmt.Sprintf(T("captcha_fail_2"), name))
 		kickUser(bot, chatID, user.ID)
 		unBanUser(bot, chatID, user.ID)
 	case 3:
-		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s falhou o captcha 3 vezes e foi banido por 24 horas.", name))
+		sendMessage(bot, chatID, fmt.Sprintf(T("captcha_fail_3"), name))
 		kickUserUntil(bot, chatID, user.ID, time.Now().Add(24*time.Hour))
 	default:
-		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s falhou o captcha após as 24h e foi banido permanentemente.", name))
+		sendMessage(bot, chatID, fmt.Sprintf(T("captcha_fail_max"), name))
 		banUser(bot, chatID, user.ID)
 	}
 }

--- a/src/captcha.go
+++ b/src/captcha.go
@@ -143,7 +143,7 @@ func (x *opBot) captchaReaper(bot tgbotInterface, chatID int64, user tgbotapi.Us
 		name := nameRef(user)
 
 		// check if this user is already banned and possibly skip some of the following steps.
-		banned, err := isBanned(bot, chatID, user.ID)
+		_, err := isBanned(bot, chatID, user.ID)
 		if err != nil {
 			log.Printf("Warning: Unable to get information for user %s (uid=%d): %v", name, user.ID, err)
 		}
@@ -152,29 +152,7 @@ func (x *opBot) captchaReaper(bot tgbotInterface, chatID int64, user tgbotapi.Us
 		// in the pending captcha list, meaning they didn't confirm the
 		// captcha.
 
-		// Let's remove the pending request.
-		defer x.pendingCaptcha.del(user.ID)
-
-		// Do nothing if user is already kicked (probably by an admin).
-		if banned {
-			log.Printf("User %s (uid=%d) has already been banned (by admin?) Not unbanning.", name, user.ID)
-			return
-		}
-
-		// As the user is not yet banned, proceed to kick+unban.
-		// Kick user and remove from list.
-		_, err = sendMessage(bot, chatID, fmt.Sprintf(T("no_captcha_received"), name))
-		if err != nil {
-			log.Printf("Warning: Unable to send 'invalid captcha' message.")
-		}
-
-		if err = kickUser(bot, chatID, user.ID); err != nil {
-			log.Printf("Warning: Unable to kick user %s (uid=%d) out of the channel.", name, user.ID)
-		}
-
-		if err = unBanUser(bot, chatID, user.ID); err != nil {
-			log.Printf("Warning: Unable to UNBAN user %s (uid=%d) (May be locked out.)", name, user.ID)
-		}
+		x.handleCaptchaFailure(bot, chatID, 0, user)
 	})
 }
 
@@ -242,4 +220,86 @@ func bincode(s string) []byte {
 // captchaResendRequest returns true if the text contains a request for another captcha.
 func captchaResendRequest(s string) bool {
 	return strings.EqualFold(s, T("another_captcha"))
+}
+
+// handleCaptchaFailure deals with users who failed the captcha (timeout or wrong answer).
+func (x *opBot) handleCaptchaFailure(bot tgbotInterface, chatID int64, messageID int, user tgbotapi.User) {
+	name := nameRef(user)
+	fails := x.captchaFails.increment(user.ID)
+
+	log.Printf("User %s (uid=%d) failed captcha. Total fails: %d", name, user.ID, fails)
+
+	// Remove from pending
+	x.pendingCaptcha.del(user.ID)
+
+	banned, err := isBanned(bot, chatID, user.ID)
+	if err != nil {
+		log.Printf("Warning: Unable to get information for user %s (uid=%d): %v", name, user.ID, err)
+	}
+
+	if banned {
+		log.Printf("User %s (uid=%d) has already been banned. Not doing anything.", name, user.ID)
+		return
+	}
+
+	switch fails {
+	case 1:
+		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s não respondeu ao captcha e foi removido do grupo.", name))
+		kickUser(bot, chatID, user.ID)
+		unBanUser(bot, chatID, user.ID)
+	case 2:
+		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s não respondeu ao captcha e foi removido. Aviso: Se tentar de novo e errar será removido por 24h.", name))
+		kickUser(bot, chatID, user.ID)
+		unBanUser(bot, chatID, user.ID)
+	case 3:
+		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s falhou o captcha 3 vezes e foi banido por 24 horas.", name))
+		kickUserUntil(bot, chatID, user.ID, time.Now().Add(24*time.Hour))
+	default:
+		sendMessage(bot, chatID, fmt.Sprintf("Usuário %s falhou o captcha após as 24h e foi banido permanentemente.", name))
+		banUser(bot, chatID, user.ID)
+	}
+}
+
+const captchaFailuresDB = "captcha_failures.json"
+
+type captchaFailures struct {
+	sync.RWMutex
+	Failures map[int]int `json:"failures"`
+}
+
+func newCaptchaFailures() *captchaFailures {
+	cf := &captchaFailures{
+		Failures: map[int]int{},
+	}
+	cf.load()
+	return cf
+}
+
+func (c *captchaFailures) load() {
+	c.Lock()
+	defer c.Unlock()
+	readJSONFromDataDir(&c.Failures, captchaFailuresDB)
+	if c.Failures == nil {
+		c.Failures = map[int]int{}
+	}
+}
+
+func (c *captchaFailures) save() error {
+	return safeWriteJSON(c.Failures, captchaFailuresDB)
+}
+
+func (c *captchaFailures) increment(userID int) int {
+	c.Lock()
+	defer c.Unlock()
+	c.Failures[userID]++
+	fails := c.Failures[userID]
+	c.save()
+	return fails
+}
+
+func (c *captchaFailures) reset(userID int) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.Failures, userID)
+	c.save()
 }

--- a/translations/en-us-all.toml
+++ b/translations/en-us-all.toml
@@ -11,6 +11,13 @@ enter_captcha = "Hello %s. Welcome to the group. *Please type the number above* 
 no_captcha_received = "User %s did not respond to the captcha and was removed from the group."
 another_captcha = "another"
 
+# Captcha failure messages.
+
+captcha_fail_1 = "User %s did not respond to the captcha and was removed from the group."
+captcha_fail_2 = "User %s did not respond to the captcha and was removed. Warning: If you try again and fail, you will be removed for 24h."
+captcha_fail_3 = "User %s failed the captcha 3 times and was banned for 24 hours."
+captcha_fail_max = "User %s failed the captcha after 24h and was banned permanently."
+
 # Register help messages.
 
 register_hackerdetected = "Fire the anti-hacker countermeasures. :)"

--- a/translations/pt-br-all.toml
+++ b/translations/pt-br-all.toml
@@ -11,6 +11,13 @@ no_captcha_received = "Usuário %s não respondeu ao captcha e foi removido do g
 enter_captcha = "Bem-vindo(a) %s. Para confirmar a sua entrada no grupo, *digite o número acima* (sem espaços, apenas os dígitos) ou a palavra *outro* para obter um número diferente. *O bot o expulsará do grupo se o número correto não for digitado em 60s!* Qualquer outra mensagem será automaticamente apagada, até que o número correto seja digitado. Em caso de problemas, por favor entre em contato com os administradores do grupo."
 another_captcha = "outro"
 
+# Captcha failure messages.
+
+captcha_fail_1 = "Usuário %s não respondeu ao captcha e foi removido do grupo."
+captcha_fail_2 = "Usuário %s não respondeu ao captcha e foi removido. Aviso: Se tentar de novo e errar será removido por 24h."
+captcha_fail_3 = "Usuário %s falhou o captcha 3 vezes e foi banido por 24 horas."
+captcha_fail_max = "Usuário %s falhou o captcha após as 24h e foi banido permanentemente."
+
 # Register help messages.
 
 register_hackerdetected = "Dispara o alarme anti-hacker. :)"


### PR DESCRIPTION
## Description

This PR introduces a progressive punitive system to prevent spam bots from repeatedly rejoining the group after failing the captcha.

### Changes

- **1st Failure:** User is kicked from the group.
- **2nd Failure:** User is kicked and warned about a potential 24h ban.
- **3rd Failure:** User receives a 24-hour temporary ban (utilizing Telegram's `UntilDate` attribute).
- **4th Failure:** User receives a permanent ban.
- **Reset:** If a user successfully passes the captcha at any point, their failure count is reset to zero.

### Technical Details

- Implemented `captchaFailures` struct to track user failure counts.
- Added data persistence via `captcha_failures.json` so the state is kept across bot restarts.
- Added `kickUserUntil` in `ban.go` to handle time-bound bans using the Telegram API.